### PR TITLE
Fix: updated code so that we can build the entire solution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,6 @@ Assembler.Main/obj/
 /Assembler.Tests/obj/project.nuget.cache
 /Assembler.Tests/bin/Debug/net9.0/Debug - Comandă rapidă.lnk
 /ControlUnit/obj/Debug/net9.0/ref/ControlUnit.dll
+
+# Unit test trace
+/CPU.Tests/SnapShots.txt

--- a/CPU.Business/CPU.Business.sln
+++ b/CPU.Business/CPU.Business.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.2.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CPU.Business", "CPU.Business.csproj", "{AB91A737-D0AE-EF38-3423-E7AB4613BD5A}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{AB91A737-D0AE-EF38-3423-E7AB4613BD5A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AB91A737-D0AE-EF38-3423-E7AB4613BD5A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AB91A737-D0AE-EF38-3423-E7AB4613BD5A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AB91A737-D0AE-EF38-3423-E7AB4613BD5A}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {FBED7B1C-54C3-4283-BD14-AF5CF984D237}
+	EndGlobalSection
+EndGlobal

--- a/CPU.Business/Models/GPR.cs
+++ b/CPU.Business/Models/GPR.cs
@@ -17,6 +17,5 @@ public enum GPR
     R12,
     R13,
     R14,
-    R15,
-    MAX
+    R15
 }

--- a/CPU.Main/Program.cs
+++ b/CPU.Main/Program.cs
@@ -1,7 +1,7 @@
 ﻿using System.Security.Cryptography;
 using Cpu = CPU.Business.CPU;
 using Ram = MainMemory.Business.MainMemory;
-using MemWrapper = MainMemory.Business.Models.MomeryContentWrapper;
+using MemWrapper = MainMemory.Business.Models.MemoryContentWrapper;
 using ASM = Assembler.Business.Assembler;
 using CPU.Business.Models;
 namespace CPU.Main

--- a/CPU.Tests/B1InstructionsTests.cs
+++ b/CPU.Tests/B1InstructionsTests.cs
@@ -1,7 +1,7 @@
 ﻿using System.Security.Cryptography;
 using Cpu = CPU.Business.CPU;
 using Ram = MainMemory.Business.MainMemory;
-using MemWrapper = MainMemory.Business.Models.MomeryContentWrapper;
+using MemWrapper = MainMemory.Business.Models.MemoryContentWrapper;
 using ASM = Assembler.Business.Assembler;
 using CPU.Business.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/CPU.Tests/CpuTestsUtils.cs
+++ b/CPU.Tests/CpuTestsUtils.cs
@@ -1,7 +1,7 @@
 using System.Security.Cryptography;
 using Cpu = CPU.Business.CPU;
 using Ram = MainMemory.Business.MainMemory;
-using MemWrapper = MainMemory.Business.Models.MomeryContentWrapper;
+using MemWrapper = MainMemory.Business.Models.MemoryContentWrapper;
 using ASM = Assembler.Business.Assembler;
 using CPU.Business.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/MainMemory.BusinessTests/MainMemoryTests.cs
+++ b/MainMemory.BusinessTests/MainMemoryTests.cs
@@ -5,18 +5,21 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using MemWrapper = MainMemory.Business.Models.MemoryContentWrapper;
 
 namespace MainMemory.Business.Tests
 {
     [TestClass()]
     public class MainMemoryTests
     {
+        MemWrapper? memWrapper;
         MainMemory? dummyRAM;
 
         [TestInitialize]
         public void Setup()
         {
-            this.dummyRAM = new MainMemory();
+            this.memWrapper = new MemWrapper();
+            this.dummyRAM = new MainMemory(memWrapper);
         }
 
         [TestMethod()]
@@ -29,20 +32,20 @@ namespace MainMemory.Business.Tests
             for (int i = 0; i < machineCode.Length; i++)
                 machineCode[i] = (byte)rnd.Next(0, 2);
 
-            Assert.ThrowsException<InvalidOperationException>(() => this.dummyRAM.SetInternalMachineCode(machineCode));
+            Assert.ThrowsException<InvalidOperationException>(() => this.dummyRAM.LoadMachineCode(machineCode));
         }
 
         [TestMethod()]
         public void SetInternalStackSizeTest()
         {
-            Assert.ThrowsException<InvalidOperationException>(() => this.dummyRAM.SetInternalStackSize(this.dummyRAM.GetMemorySize()));
+            Assert.ThrowsException<InvalidOperationException>(() => this.dummyRAM.SetStackSize(this.dummyRAM.GetMemorySize()));
 
         }
 
         [TestMethod()]
         public void SetInternalISRTest()
         {
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => this.dummyRAM.SetInternalISR(21, null));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => this.dummyRAM.SetISR(21, null));
 
         }
 
@@ -52,7 +55,7 @@ namespace MainMemory.Business.Tests
             ushort interruptReturnOpCode = 0xe00f;
             int interruptSizeMax = 0x1db9;
             ushort isrSegment = 0x2fed;
-            byte[] memoryDump = this.dummyRAM.GetInternalMemoryDump();
+            byte[] memoryDump = this.dummyRAM.GetMemoryDump();
             bool ok = true;
 
             for(int i = isrSegment; (i < interruptSizeMax - 1) && ok; i+=2)


### PR DESCRIPTION
# What is the issue?
Currently we cannot build the entire solution, i.e. the application modules and unit tests.
# What was done?
- fixed class naming where it was needed
- updated code for `MainMemory` unit tests so that it uses the newly introduced wrapper
- fixed bug in `GPR` enum where it would use index 16 (even though the enum goes up to 15)
# How to review?
Build the entire solution using `dotnet build` and run the unit tests.
## Note
If you see any failed jobs this is due misconfigured parameters such as `Solution_Name: your-solution-name`.