### PR TITLE
Minor: Updated CPU logic for `HALT` instruction.

### DIFF
--- a/CPU.Business/CPU.cs
+++ b/CPU.Business/CPU.cs
@@ -60,6 +60,8 @@ namespace CPU.Business
 
         public RegisterWrapper Registers;
         public short SBUS, DBUS, RBUS;
+        private bool BPO; //Bistabil Pornire/Oprire
+        private int previousMIRIndexState, previousMARState;
         private ControlUnit _controlUnit;
         private IMainMemory _mainMemory;
         public bool ACLOW, INT, CIL;
@@ -78,10 +80,15 @@ namespace CPU.Business
             _microProgram = new OrderedDictionary<string, string[][]>();
             Registers = registers;
             Registers[REGISTERS.ONES] = -1;
+            BPO = true; //Enable CPU clock
+            previousMARState = 0;
+            previousMIRIndexState = 0;
         }
         public (int MAR, int MirIndex) StepMicrocommand()
         {
-            return _controlUnit.StepMicrocommand(ACLOW, Registers[REGISTERS.FLAGS]);
+            if(BPO)
+                (previousMARState,previousMIRIndexState) = _controlUnit.StepMicrocommand(ACLOW, Registers[REGISTERS.FLAGS]);
+            return (previousMARState, previousMIRIndexState);
         }
         /// <summary>
         /// This will load the json MPM configuration in the actual MPM.
@@ -193,6 +200,7 @@ namespace CPU.Business
             }
             _mainMemory.ClearMemory();
             _controlUnit.Reset();
+            BPO = true; //Reactivate CPU clock
         }
         public string GetCurrentLabel(int MAR)
         {
@@ -413,6 +421,11 @@ namespace CPU.Business
                     break;
                 case OTHER_EVENTS.A0BE_A0BI:
                     //resetarea bitilor de exceptie;
+                    break;
+                case OTHER_EVENTS.A0BPO:
+                    //Adu la 0 BPO
+                    //Disable CPU clock
+                    BPO = false;
                     break;
             }
         }


### PR DESCRIPTION
# What is the issue?
Currently `HALT` instruction which is supposed to stop the processor is not implemented.
# What has been done?
Added `BPO` (Bistabil Pornire Oprire) as flag which shall act as the real flip flop circuit.
## Notes
- If you look over the ticket description you shall see that `BPO` was supposed to be placed in a loop, however in our implementation the UI acts as the loop that requests the step functionality.
<img width="606" height="419" alt="image" src="https://github.com/user-attachments/assets/b975f961-77fe-4324-ae9f-ace5ceaa717e" />
- With this implementation the code cannot be stepped further that `A(0)BPO` micro-command, thus `HALT` instruction does not executes entirely. @AndreiSaldorfean I need your opinion on this.
<img width="1182" height="60" alt="halt" src="https://github.com/user-attachments/assets/e65ac862-e831-4e70-972a-4c8cd9f183f3" />

# How to review?
Code review and set `MAR` value to `0x60` with the debugger so that the micro-instruction is taken. Currently the jump from `B4` label does not executes correctly (the issue shall be addressed in a later ticket), thus this trick is needed.
