### PR TITLE
Patch MPM's subtraction logic

### DIFF
--- a/CPU.Business/CPU.cs
+++ b/CPU.Business/CPU.cs
@@ -270,7 +270,7 @@ namespace CPU.Business
                     RBUS = (short)(SBUS + DBUS);
                     break;
                 case ALU_OP.SUB:
-                    RBUS = (short)(SBUS - DBUS);
+                    RBUS = (short)(SBUS + DBUS + 1);
                     break;
                 case ALU_OP.AND:
                     RBUS = (short)(SBUS & DBUS);

--- a/Configs/MPM.json
+++ b/Configs/MPM.json
@@ -130,7 +130,7 @@
     ],
     "INC":
     [
-        ["Pd0s",      "PdMDRd",        "SUM",   "PmMDR",       "NONE",    "Cin,PdCONDaritm", "JUMPI",            "INDEX3",  "T",  "WRD"          ]
+        ["Pd-1s",     "PdMDRd",        "SUB",   "PmMDR",       "NONE",    "PdCONDaritm",     "JUMPI",            "INDEX3",  "T",  "WRD"          ]
     ],
     "DEC":
     [

--- a/Configs/MPM.json
+++ b/Configs/MPM.json
@@ -102,7 +102,7 @@
     ],
     "SUB":
     [
-        ["PdTsNeg",   "PdMDRd",        "SUM",   "PmMDR",       "NONE",    "Cin,PdCONDaritm", "JUMPI",            "INDEX3",  "T",  "WRD"          ]
+        ["PdTsNeg",   "PdMDRd",        "SUB",   "PmMDR",       "NONE",    "Cin,PdCONDaritm", "JUMPI",            "INDEX3",  "T",  "WRD"          ]
     ],
     "CMP":
     [

--- a/Configs/MPM.json
+++ b/Configs/MPM.json
@@ -98,15 +98,15 @@
     ],
     "ADD":
     [
-        ["PdTs",      "PdMDRd",        "SUM",   "PmMDR",       "NONE",    "Cin,PdCONDaritm", "JUMPI",            "INDEX3",  "T",  "WRD"          ]
+        ["PdTs",      "PdMDRd",        "SUM",   "PmMDR",       "NONE",    "PdCONDaritm",     "JUMPI",            "INDEX3",  "T",  "WRD"          ]
     ],
     "SUB":
     [
-        ["PdTsNeg",   "PdMDRd",        "SUB",   "PmMDR",       "NONE",    "Cin,PdCONDaritm", "JUMPI",            "INDEX3",  "T",  "WRD"          ]
+        ["PdTsNeg",   "PdMDRd",        "SUB",   "PmMDR",       "NONE",    "PdCONDaritm", "JUMPI",                "INDEX3",  "T",  "WRD"          ]
     ],
     "CMP":
     [
-        ["PdTsNeg",   "PdMDRd",        "SUM",   "NONE",        "NONE",    "Cin,PdCONDaritm", "JUMPI",            "INDEX7",  "T",  "IFCH"         ]
+        ["PdTsNeg",   "PdMDRd",        "SUB",   "NONE",        "NONE",    "PdCONDaritm", "JUMPI",                "INDEX7",  "T",  "IFCH"         ]
     ],
     "AND":
     [


### PR DESCRIPTION
# What?

As of now subtraction attempts to happen using addition in a manually calculated Two's complement, using the `CinPdCONDaritm`.

**This creates a critical issue.**

# Why?

The critical issue comes from the fact that the Carry in is set to 1 **after** `ALU` operation happens, whilst it should come **before** so that the Carry in would be included in the calculation.
<img width="1693" height="330" alt="image" src="https://github.com/user-attachments/assets/56bbb823-49ff-42ec-a104-d6731a1173ba" />


Another issue is that in excel MPM there is an ALU microcommand `SUB` that is never used.
<img width="1319" height="707" alt="image" src="https://github.com/user-attachments/assets/e159c47c-8bcc-4391-8f59-b01c1cc53db3" />


# How?

I replaced `CinPdCONDaritm` with `PdCONDaritm` and used `SUB` instead of `SUM` and implemented `SUB` micro-command according to TWO's Complement subtraction (i.e. RBUS= ~SBUS + DBUS + 1, C2= C1+1, C1= ~x, x - number)