### PR TITLE
feature: Added CI/CD job for generating releases

### DIFF
--- a/.github/workflows/genereate_release.yaml
+++ b/.github/workflows/genereate_release.yaml
@@ -1,0 +1,38 @@
+name: Generate Release
+
+on:
+  push:
+    tags:
+    - '*'
+env:
+  RELEASE_DIR: Release
+  EXECUTABLE_PROJ: Ui
+jobs:
+  gen_release:
+    runs-on: ubuntu-latest #Ubuntu is smaller in size than Windows
+    permissions:
+      contents: write # permission to upload artefacts
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Publish application
+        id: publish
+        run:
+          dotnet publish -c Release -r win-x64 -p:EnableWindowsTargeting=true -p:PublishSingleFile=true -p:SelfContained=true -o $RELEASE_DIR $EXECUTABLE_PROJ/$EXECUTABLE_PROJ.csproj
+          # please check https://learn.microsoft.com/en-us/dotnet/core/tools/sdk-errors/netsdk1100
+          # for more information
+      - name: Archive release
+        run: |
+          sudo apt install -y  zip
+          zip -r $RELEASE_DIR.zip $RELEASE_DIR
+
+      - name: Upload release
+        uses: ncipollo/release-action@v1
+        with:
+           artifacts: ${{ env.RELEASE_DIR }}.zip

--- a/.gitignore
+++ b/.gitignore
@@ -175,4 +175,8 @@ Assembler.Main/obj/
 /ControlUnit/obj/Debug/net9.0/ref/ControlUnit.dll
 
 # Unit test trace
-/CPU.Tests/SnapShots.txt
+/CPU.Tests/SnapShots_*
+
+# Application release
+/Release/*
+Release.rar

--- a/Ui/Ui.csproj
+++ b/Ui/Ui.csproj
@@ -4,6 +4,7 @@
         <OutputType>WinExe</OutputType>
         <TargetFramework>net9.0-windows</TargetFramework>
         <ApplicationManifest>app.manifest</ApplicationManifest>
+        <AssemblyName>MicroCISC</AssemblyName>
         <ApplicationIcon>wpfui-icon.ico</ApplicationIcon>
         <UseWPF>true</UseWPF>
         <Nullable>enable</Nullable>


### PR DESCRIPTION
# What is the issue?
Currently we have no mechanism of generating releases automatically based updates.
# What has been done?
A new CI/CD job has been added that generates a release based on pushed tags. The release shall contain the source code needed for development and the excutable file (with the necessary libraries) intended for users.
# How to review?
Normally I would suggest using `act` together with `Docker` in order to run it locally. However, for the release publishing part you would need to add a Github token in order for it to work. Thus, two things could be done:
- code review
- add tags as test
## Note:
The application is not signed, thus it is not trusted by Windows and the user shall get a warning window for the first run. Our budget does not allow us purchasing official licenses.