### PR TITLE
88 UI highlight rows when stepping at instruction level

### DIFF
--- a/Ui/App.xaml.cs
+++ b/Ui/App.xaml.cs
@@ -57,7 +57,7 @@ public partial class App : Application
             services.AddSingleton<IDiagramViewModel, DiagramViewModel>();
             services.AddSingleton<IHexViewModel, HexViewModel>();
             services.AddSingleton<ISettingsViewModel, SettingsViewModel>();
-            services.AddSingleton<CpuService>();
+            services.AddSingleton<ICpuService, CpuService>();
             services.AddSingleton<IMicroprogramViewModel, MicroprogramViewModel>();
             services.AddSingleton<IMainMemory, MainMemory.Business.MainMemory>();
             services.AddSingleton<CPU.Business.CPU>();

--- a/Ui/Helpers/HighlightCurrentLineBackgroundRenderer.cs
+++ b/Ui/Helpers/HighlightCurrentLineBackgroundRenderer.cs
@@ -1,0 +1,39 @@
+﻿using ICSharpCode.AvalonEdit;
+using ICSharpCode.AvalonEdit.Rendering;
+using System.Windows.Media;
+
+public class HighlightCurrentLineBackgroundRenderer : IBackgroundRenderer
+{
+    private readonly TextEditor _editor;
+    private int _lineNumber;
+    private readonly SolidColorBrush _highlightBrush;
+
+    public HighlightCurrentLineBackgroundRenderer(TextEditor editor, int lineNumber, Color color)
+    {
+        _editor = editor;
+        _lineNumber = lineNumber;
+        _highlightBrush = new SolidColorBrush(color);
+        _highlightBrush.Freeze();
+    }
+
+    public void SetLine(int lineNumber)
+    {
+        _lineNumber = lineNumber;
+        _editor.TextArea.TextView.InvalidateLayer(KnownLayer.Background);
+    }
+
+    public KnownLayer Layer => KnownLayer.Background;
+
+    public void Draw(TextView textView, DrawingContext drawingContext)
+    {
+        if (_lineNumber <= 0) return;
+        textView.EnsureVisualLines();
+
+        var line = _editor.Document.GetLineByNumber(_lineNumber);
+        foreach (var rect in BackgroundGeometryBuilder.GetRectsForSegment(textView, line))
+        {
+            drawingContext.DrawRectangle(_highlightBrush, null,
+                new System.Windows.Rect(rect.X, rect.Y, textView.ActualWidth, rect.Height));
+        }
+    }
+}

--- a/Ui/Interfaces/Services/ICpuService.cs
+++ b/Ui/Interfaces/Services/ICpuService.cs
@@ -1,7 +1,14 @@
+using Ui.ViewModels.Generics;
+
 namespace Ui.Interfaces.Services;
 
 public interface ICpuService
 {
+    HighlightCurrentLineBackgroundRenderer? Highlight { get; set; }
     Task LoadJsonMpm(string filePath = "", bool debug = false);
     (int, int) StepMicrocommand();
+    public void SetActiveEditor(FileViewModel fileViewModel);
+    public void ResetProgram();
+    public void StartDebugging();
+    public void StopDebugging();
 }

--- a/Ui/Interfaces/ViewModel/IActionsBarViewModel.cs
+++ b/Ui/Interfaces/ViewModel/IActionsBarViewModel.cs
@@ -13,11 +13,18 @@ public interface IActionsBarViewModel
 
     /// <summary>Gets an <see cref="global::CommunityToolkit.Mvvm.Input.IRelayCommand"/> instance wrapping <see cref="ActionsBarViewModel.StepMicroprogram"/>.</summary>
     global::CommunityToolkit.Mvvm.Input.IRelayCommand StepMicroprogramCommand { get; }
+    /// <summary>Gets an <see cref="global::CommunityToolkit.Mvvm.Input.IRelayCommand"/> instance wrapping <see cref="ActionsBarViewModel.StartDebug"/>.</summary>
+    global::CommunityToolkit.Mvvm.Input.IRelayCommand StartDebugCommand { get; }
+    /// <summary>Gets an <see cref="global::CommunityToolkit.Mvvm.Input.IRelayCommand"/> instance wrapping <see cref="ActionsBarViewModel.StopDebug"/>.</summary>
+    global::CommunityToolkit.Mvvm.Input.IRelayCommand StopDebugCommand { get; }
 
     /// <summary>Gets an <see cref="global::CommunityToolkit.Mvvm.Input.IAsyncRelayCommand"/> instance wrapping <see cref="ActionsBarViewModel.LoadJson"/>.</summary>
     global::CommunityToolkit.Mvvm.Input.IAsyncRelayCommand LoadJsonCommand { get; }
     /// <summary>Gets an <see cref="global::CommunityToolkit.Mvvm.Input.IAsyncRelayCommand"/> instance wrapping <see cref="ActionsBarViewModel.ResetProgram"/>.</summary>
     global::CommunityToolkit.Mvvm.Input.IRelayCommand ResetProgramCommand { get; }
+
+    bool IsDebugging { get; set; }
+    bool NotDebugging { get; set; }
 
     event EventHandler<byte[]>? ObjectCodeGenerated;
 

--- a/Ui/ViewModels/Generics/ActionsBarViewModel.cs
+++ b/Ui/ViewModels/Generics/ActionsBarViewModel.cs
@@ -10,15 +10,22 @@ public partial class ActionsBarViewModel : ObservableObject, IActionsBarViewMode
 {
     private readonly IActiveDocumentService _activeDocumentService;
     private readonly IAssemblerService _assemblerService;
-    private readonly CpuService _cpuService;
+    private readonly ICpuService _cpuService;
     private readonly IToolVisibilityService _toolVisibilityService;
 
-    public ActionsBarViewModel(IAssemblerService assemblerService, IActiveDocumentService activeDocumentService, CpuService cpuService, IToolVisibilityService toolVisibilityService)
+    [ObservableProperty]
+    public partial bool IsDebugging { get; set; }
+    [ObservableProperty]
+    public partial bool NotDebugging { get; set; }
+
+    public ActionsBarViewModel(IAssemblerService assemblerService, IActiveDocumentService activeDocumentService, ICpuService cpuService, IToolVisibilityService toolVisibilityService)
     {
         _assemblerService = assemblerService;
         _activeDocumentService = activeDocumentService;
         _cpuService = cpuService;
         _toolVisibilityService = toolVisibilityService;
+        IsDebugging = false;
+        NotDebugging = true;
         ObjectCodeGenerated += OnObjectCodeGenerated;
     }
 
@@ -55,6 +62,26 @@ public partial class ActionsBarViewModel : ObservableObject, IActionsBarViewMode
     private void StepMicroprogram()
     {
         _cpuService.StepMicrocommand();
+    }
+    [RelayCommand]
+    private void StartDebug()
+    {
+        if (_activeDocumentService.SelectedDocument != null)
+        {
+            _cpuService.StartDebugging();
+            IsDebugging = true;
+            NotDebugging = false;
+        }
+    }
+    [RelayCommand]
+    private void StopDebug()
+    {
+        if (_activeDocumentService.SelectedDocument != null)
+        {
+            _cpuService.StopDebugging();
+            IsDebugging = false;
+            NotDebugging = true;
+        }
     }
     [RelayCommand]
     private void ResetProgram()

--- a/Ui/ViewModels/Generics/FileViewModel.cs
+++ b/Ui/ViewModels/Generics/FileViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using Ui.Components;
 
 namespace Ui.ViewModels.Generics;
 
@@ -12,7 +13,9 @@ public partial class FileViewModel : PaneViewModel
     [ObservableProperty] public partial string Content { get; set; } = string.Empty;
 
     [ObservableProperty] public partial string? FilePath { get; set; }
-    
+
+    public StyledAvalonEdit? EditorInstance { get; set; }
+
     public async Task LoadFromFile(string path)
     {
         FilePath = path;

--- a/Ui/Views/Windows/MainWindow.xaml
+++ b/Ui/Views/Windows/MainWindow.xaml
@@ -124,6 +124,8 @@
             </ui:Button>
 
             <ui:Button
+                Command="{Binding StartDebugCommand}"
+                IsEnabled="{Binding NotDebugging}"
                 VerticalAlignment="Top"
                 ToolTip="Debug"
                 Height="30"
@@ -149,6 +151,7 @@
 
             <ui:Button
                 Command="{Binding StepMicroprogramCommand}"
+                IsEnabled="{Binding IsDebugging}"
                 VerticalAlignment="Top"
                 ToolTip="Step Into"
                 Height="30"
@@ -163,6 +166,7 @@
             <ui:Button
                 VerticalAlignment="Top"
                 ToolTip="Step Over"
+                IsEnabled="{Binding IsDebugging}"
                 Height="30"
                 Width="30"
                 Padding="0"
@@ -174,6 +178,7 @@
 
             <ui:Button
                 Command="{Binding ResetProgramCommand}"
+                IsEnabled="{Binding IsDebugging}"
                 VerticalAlignment="Top"
                 ToolTip="Reset"
                 Height="30"
@@ -186,7 +191,9 @@
             </ui:Button>
 
             <ui:Button
+                Command="{Binding StopDebugCommand}"
                 VerticalAlignment="Top"
+                IsEnabled="{Binding IsDebugging}"
                 ToolTip="Stop"
                 Height="30"
                 Width="30"
@@ -219,7 +226,8 @@
                                 FontFamily="Consolas"
                                 FontSize="10pt"
                                 ShowLineNumbers="True"
-                                Text="{Binding Content, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
+                                Text="{Binding Content, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}"
+                                Loaded="OnEditorLoaded"/>
                         </DataTemplate>
                     </components:PanesTemplateSelector.FileViewTemplate>
                     <!-- Properties -->

--- a/Ui/Views/Windows/MainWindow.xaml.cs
+++ b/Ui/Views/Windows/MainWindow.xaml.cs
@@ -1,21 +1,27 @@
 using System.ComponentModel;
 using AvalonDock;
+using Ui.Components;
+using ICSharpCode.AvalonEdit;
 using Ui.Interfaces.Services;
 using Ui.Interfaces.ViewModel;
 using Ui.Services;
+using Ui.ViewModels.Generics;
 using Wpf.Ui.Appearance;
 
 namespace Ui.Views.Windows;
 
 public partial class MainWindow
 {
+    ICpuService _cpuService;
     public MainWindow(
-        IMainWindowViewModel viewModel
+        IMainWindowViewModel viewModel,
+        ICpuService cpuService
     )
     {
         DataContext = viewModel;
         SystemThemeWatcher.Watch(this);
         InitializeComponent();
+        _cpuService = cpuService;
     }
 
     public void SetServiceProvider(IServiceProvider serviceProvider)
@@ -63,5 +69,13 @@ public partial class MainWindow
     {
         _docking.SaveLastUsedLayout();
         base.OnClosing(e);
+    }
+    private void OnEditorLoaded(object sender, RoutedEventArgs e)
+    {
+        if (sender is StyledAvalonEdit editor && editor.DataContext is FileViewModel vm)
+        {
+            vm.EditorInstance = editor;
+            _cpuService.SetActiveEditor(vm);
+        }
     }
 }


### PR DESCRIPTION
# What?

Add support for highlighting rows in avalon edit when stepping instructions.

I also disabled the debugging buttons by default, they will work only when you enter in debug mode by clicking the debug button.

<img width="1110" height="649" alt="image" src="https://github.com/user-attachments/assets/9170e3e2-50d6-481d-998d-c935456460a9" />

When you enter in debug mode the row shall be highlighted, and the buttons shall work:
<img width="1096" height="583" alt="image" src="https://github.com/user-attachments/assets/32d4bff7-d9f4-4f07-bbe7-e716585a7ca3" />
And when you quit it shall disappear, and the button shall be disabled:
<img width="1079" height="629" alt="image" src="https://github.com/user-attachments/assets/9f99163a-5440-442c-922d-fbce6683898d" />
Also debugging wont start unless you have avalon edit opened

**At the moment the highlighted row doesn't reflect where the PC is, this is yet to be implemented here:**
https://github.com/users/florinres/projects/2/views/1?pane=issue&itemId=124531055&issue=florinres%7CCISCraft%7C98
