### PR TITLE
98 backend add debugging symbols for stepping at instruction level

### DIFF
--- a/Assembler.Business/Assembler.cs
+++ b/Assembler.Business/Assembler.cs
@@ -44,5 +44,9 @@ namespace Assembler.Business
             }
             return Encoder.Encode(tree.Root, out len);
         }
+        public Dictionary<short, ushort> GetDebugSymbols()
+        {
+            return Encoder.DebugSymbols;
+        }
     }
 }

--- a/CPU.Business/CPU.cs
+++ b/CPU.Business/CPU.cs
@@ -347,11 +347,11 @@ namespace CPU.Business
                 case 0 /* None */:
                     break;
                 case 1 /* IFCH */:
-                    _controlUnit.IR = _mainMemory.FetchWord(Registers[REGISTERS.ADR]);
+                    _controlUnit.IR = _mainMemory.FetchWord((ushort)Registers[REGISTERS.ADR]);
                     Registers[REGISTERS.IR] = _controlUnit.IR; // For updateing the UI
                     break;
                 case 2 /* READ */:
-                    Registers[REGISTERS.MDR] = _mainMemory.FetchWord(Registers[REGISTERS.ADR]);
+                    Registers[REGISTERS.MDR] = _mainMemory.FetchWord((ushort)Registers[REGISTERS.ADR]);
                     break;
                 case 3 /* WRITE */:
                     _mainMemory.SetWordLocation(Registers[REGISTERS.ADR], Registers[REGISTERS.MDR]);

--- a/Ui/Assets/Mpm.json
+++ b/Ui/Assets/Mpm.json
@@ -1,343 +1,343 @@
 {
-  "IFCH":
-  [
-    ["PdPCs",     "NONE",          "SBUS",  "PmADR",       "IFCH",    "+2PC",            "IF ACLOW JUMPI",   "INDEX0",  "T",  "PWFAIL"       ],
-    ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "IF CIL JUMPI",     "INDEX1",  "F",  "B1"           ]
-  ],
-  "ILLEGAL":
-  [
-    ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "A(1)BE1",         "JUMPI",            "INDEX0",  "T",  "INT"          ]
-  ],
-  "PWFAIL":
-  [
-    ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "A(1)BE0",         "JUMPI",            "INDEX0",  "T",  "INT"          ]
-  ],
-  "INT":
-  [
-    ["PdSPs",     "NONE",          "SBUS",  "PmADR",       "NONE",    "INTA,-2SP",       "STEP",             "INDEX0",  "T",  "0"            ],
-    ["PdFLAGs",   "NONE",          "SBUS",  "PmMDR",       "NONE",    "-2SP",            "STEP",             "INDEX0",  "T",  "0"            ],
-    ["PdSPs",     "NONE",          "SBUS",  "PmADR",       "NONE",    "NONE",            "STEP",             "INDEX0",  "T",  "0"            ],
-    ["PdPCs",     "NONE",          "SBUS",  "PmMDR",       "WRITE",   "NONE",            "STEP",             "INDEX0",  "T",  "0"            ],
-    ["PdIVRs",    "NONE",          "SBUS",  "PmADR",       "READ",    "NONE",            "STEP",             "INDEX0",  "T",  "0"            ],
-    ["PdMDRs",    "NONE",          "SBUS",  "PmPC",        "NONE",    "A(0)BE,A(0)BI",   "JUMPI",            "INDEX0",  "T",  "IFCH"         ]
-  ],
-  "B1":
-  [
-    ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "JUMPI",            "INDEX2",  "T",  "FOS_AM"       ]
-  ],
-  "B2":
-  [
-    ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "JUMPI",            "INDEX3",  "T",  "FOD_AM_B2"    ]
-  ],
-  "B3":
-  [
-    ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "JUMPI",            "INDEX5",  "T",  "BEQ"          ]
-  ],
-  "B4":
-  [
-    ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "JUMPI",            "INDEX5",  "T",  "CLC"          ]
-  ],
-  "FOS_AM":
-  [
-    ["PdPCs",     "NONE",          "SBUS",  "PmADR",       "READ",    "+2PC",            "JUMPI",            "INDEX0",  "T",  "FOSEND"       ]
-  ],
-  "FOS_AD":
-  [
-    ["PdRGs",     "NONE",          "SBUS",  "PmT",         "NONE",    "NONE",            "JUMPI",            "INDEX3",  "T",  "FOD_AD_B1"    ]
-  ],
-  "FOS_AI":
-  [
-    ["PdRGs",     "NONE",          "SBUS",  "PmADR",       "READ",    "NONE",            "JUMPI",            "INDEX0",  "T",  "FOSEND"       ]
-  ],
-  "FOS_AX":
-  [
-    ["PdPCs",     "NONE",          "SBUS",  "PmADR",       "READ",    "+2PC",            "STEP",             "INDEX0",  "T",  "0"            ],
-    ["PdRGs",     "PdMDRd",        "SUM",   "PmADR",       "READ",    "NONE",            "STEP",             "INDEX0",  "T",  "0"            ]
-  ],
-  "FOSEND":
-  [
-    ["PdMDRs",    "NONE",          "SBUS",  "PmT",         "NONE",    "NONE",            "JUMPI",            "INDEX3",  "T",  "FOD_AM_B1"    ]
-  ],
-  "FOD_AM_B1":
-  [
-    ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "JUMPI",            "INDEX0",  "T",  "ILLEGAL"      ]
-  ],
-  "FOD_AD_B1":
-  [
-    ["NONE",      "PdRGd",         "DBUS",  "PmMDR",       "NONE",    "NONE",            "JUMPI",            "INDEX4",  "T",  "MOV"          ]
-  ],
-  "FOD_AI_B1":
-  [
-    ["NONE",      "PdRGd",         "DBUS",  "PmADR",       "READ",    "NONE",            "JUMPI",            "INDEX4",  "T",  "MOV"          ]
-  ],
-  "FOD_AX_B1":
-  [
-    ["NONE",      "PdPCd",         "DBUS",  "PmADR",       "READ",    "+2PC",            "STEP",             "INDEX0",  "T",  "0"            ],
-    ["PdMDRs",    "PdRGd",         "SUM",   "PmADR",       "READ",    "NONE",            "JUMPI",            "INDEX4",  "T",  "MOV"          ]
-  ],
-  "FOD_AM_B2":
-  [
-    ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "JUMPI",            "INDEX0",  "T",  "ILLEGAL"      ]
-  ],
-  "FOD_AD_B2":
-  [
-    ["NONE",      "PdRGd",         "DBUS",  "PmMDR",       "NONE",    "NONE",            "JUMPI",            "INDEX5",  "T",  "CLR"          ]
-  ],
-  "FOD_AI_B2":
-  [
-    ["NONE",      "PdRGd",         "DBUS",  "PmADR",       "READ",    "NONE",            "JUMPI",            "INDEX4",  "T",  "CLR"          ]
-  ],
-  "FOD_AX_B2":
-  [
-    ["NONE",      "PdPCd",         "DBUS",  "PmADR",       "READ",    "+2PC",            "STEP",             "INDEX0",  "T",  "0"            ],
-    ["PdMDRs",    "PdRGd",         "SUM",   "PmADR",       "READ",    "NONE",            "JUMPI",            "INDEX4",  "T",  "CLR"          ]
-  ],
-  "MOV":
-  [
-    ["PdTs",      "NONE",          "SBUS",  "PmMDR",       "NONE",    "NONE",            "JUMPI",            "INDEX3",  "T",  "WRD"          ]
-  ],
-  "ADD":
-  [
-    ["PdTs",      "PdMDRd",        "SUM",   "PmMDR",       "NONE",    "Cin,PdCONDaritm", "JUMPI",            "INDEX3",  "T",  "WRD"          ]
-  ],
-  "SUB":
-  [
-    ["PdTsNeg",   "PdMDRd",        "SUM",   "PmMDR",       "NONE",    "Cin,PdCONDaritm", "JUMPI",            "INDEX3",  "T",  "WRD"          ]
-  ],
-  "CMP":
-  [
-    ["PdTsNeg",   "PdMDRd",        "SUM",   "NONE",        "NONE",    "Cin,PdCONDaritm", "JUMPI",            "INDEX7",  "T",  "IFCH"         ]
-  ],
-  "AND":
-  [
-    ["PdTs",      "PdMDRd",        "AND",   "PmMDR",       "NONE",    "PdCONDlog",       "JUMPI",            "INDEX3",  "T",  "WRD"          ]
-  ],
-  "OR":
-  [
-    ["PdTs",      "PdMDRd",        "OR",    "PmMDR",       "NONE",    "PdCONDlog",       "JUMPI",            "INDEX3",  "T",  "WRD"          ]
-  ],
-  "XOR":
-  [
-    ["PdTs",      "PdMDRd",        "XOR",   "PmMDR",       "NONE",    "PdCONDlog",       "JUMPI",            "INDEX3",  "T",  "WRD"          ]
-  ],
-  "CLR":
-  [
-    ["NONE",      "Pd0d",          "DBUS",  "PmMDR",       "NONE",    "PdCONDlog",       "JUMPI",            "INDEX3",  "T",  "WRD"          ]
-  ],
-  "NEG":
-  [
-    ["NONE",      "PdMDRdNeg",     "DBUS",  "PmMDR",       "NONE",    "PdCONDlog",       "JUMPI",            "INDEX3",  "T",  "WRD"          ]
-  ],
-  "INC":
-  [
-    ["Pd0s",      "PdMDRd",        "SUM",   "PmMDR",       "NONE",    "Cin,PdCONDaritm", "JUMPI",            "INDEX3",  "T",  "WRD"          ]
-  ],
-  "DEC":
-  [
-    ["Pd-1s",     "PdMDRd",        "SUM",   "PmMDR",       "NONE",    "PdCONDaritm",     "JUMPI",            "INDEX3",  "T",  "WRD"          ]
-  ],
-  "ASL":
-  [
-    ["NONE",      "PdMDRd",        "ASL",   "PmMDR",       "NONE",    "PdCONDaritm",     "JUMPI",            "INDEX3",  "T",  "WRD"          ]
-  ],
-  "ASR":
-  [
-    ["NONE",      "PdMDRd",        "ASR",   "PmMDR",       "NONE",    "PdCONDaritm",     "JUMPI",            "INDEX3",  "T",  "WRD"          ]
-  ],
-  "LSR":
-  [
-    ["NONE",      "PdMDRd",        "LSR",   "PmMDR",       "NONE",    "PdCONDlog",       "JUMPI",            "INDEX3",  "T",  "WRD"          ]
-  ],
-  "ROL":
-  [
-    ["NONE",      "PdMDRd",        "ROL",   "PmMDR",       "NONE",    "PdCONDlog",       "JUMPI",            "INDEX3",  "T",  "WRD"          ]
-  ],
-  "ROR":
-  [
-    ["NONE",      "PdMDRd",        "ROR",   "PmMDR",       "NONE",    "PdCONDlog",       "JUMPI",            "INDEX3",  "T",  "WRD"          ]
-  ],
-  "RLC":
-  [
-    ["NONE",      "PdMDRd",        "RLC",   "PmMDR",       "NONE",    "PdCONDlog",       "JUMPI",            "INDEX3",  "T",  "WRD"          ]
-  ],
-  "RRC":
-  [
-    ["NONE",      "PdMDRd",        "RRC",   "PmMDR",       "NONE",    "PdCONDlog",       "JUMPI",            "INDEX3",  "T",  "WRD"          ]
-  ],
-  "PUSH":
-  [
-    ["PdSPs",     "NONE",          "SBUS",  "PmADR",       "WRITE",   "-2SP",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ]
-  ],
-  "POP":
-  [
-    ["PdADRs",    "NONE",          "SBUS",  "PmT",         "NONE",    "NONE",            "STEP",             "INDEX0",  "T",  "0"            ],
-    ["PdSPs",     "NONE",          "SBUS",  "PmADR",       "READ",    "NONE",            "STEP",             "INDEX0",  "T",  "0"            ],
-    ["PdTs",      "NONE",          "SBUS",  "PmADR",       "NONE",    "+2SP",            "JUMPI",            "INDEX3",  "T",  "WRD"          ]
-  ],
-  "WRD":
-  [
-    ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "JUMPI",            "INDEX0",  "T",  "ILLEGAL"      ],
-    ["PdMDRs",    "NONE",          "SBUS",  "PmRG",        "NONE",    "NONE",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ],
-    ["NONE",      "NONE",          "NONE",  "NONE",        "WRITE",   "NONE",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ],
-    ["NONE",      "NONE",          "NONE",  "NONE",        "WRITE",   "NONE",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ]
-  ],
-  "BEQ":
-  [
-    ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "IF Z JUMPI",       "INDEX3",  "T",  "JMP_AM"       ],
-    ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ]
-  ],
-  "BNE":
-  [
-    ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "IF Z JUMPI",       "INDEX3",  "F",  "JMP_AM"       ],
-    ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ]
-  ],
-  "BMI":
-  [
-    ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "IF S JUMPI",       "INDEX3",  "T",  "JMP_AM"       ],
-    ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ]
-  ],
-  "BPL":
-  [
-    ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "IF S JUMPI",       "INDEX3",  "F",  "JMP_AM"       ],
-    ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ]
-  ],
-  "BCS":
-  [
-    ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "IF C JUMPI",       "INDEX3",  "T",  "JMP_AM"       ],
-    ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ]
-  ],
-  "BCC":
-  [
-    ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "IF C JUMPI",       "INDEX3",  "F",  "JMP_AM"       ],
-    ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ]
-  ],
-  "BVS":
-  [
-    ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "IF V JUMPI",       "INDEX3",  "T",  "JMP_AM"       ],
-    ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ]
-  ],
-  "BVC":
-  [
-    ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "IF V JUMPI",       "INDEX3",  "F",  "JMP_AM"       ],
-    ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ]
-  ],
-  "JMP":
-  [
-    ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "JUMPI",            "INDEX3",  "T",  "JMP_AM"       ],
-    ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "STEP",             "INDEX0",  "T",  "0"            ]
-  ],
-  "CALL":
-  [
-    ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "JUMPI",            "INDEX3",  "T",  "CALL_AM"      ]
-  ],
-  "CALL_AM":
-  [
-    ["PdPCs",     "NONE",          "SBUS",  "PmADR",       "READ",    "+2PC",            "JUMPI",            "INDEX0",  "T",  "CALL_2"       ]
-  ],
-  "CALL_AD":
-  [
-    ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "JUMPI",            "INDEX0",  "T",  "ILLEGAL"      ]
-  ],
-  "CALL_AI":
-  [
-    ["NONE",      "PdRGd",         "DBUS",  "PmT",         "NONE",    "NONE",            "JUMPI",            "INDEX0",  "T",  "CALL_3"       ]
-  ],
-  "CALL_AX":
-  [
-    ["PdPCs",     "NONE",          "SBUS",  "PmADR",       "READ",    "+2PC",            "STEP",             "INDEX0",  "T",  "0"            ],
-    ["PdMDRs",    "PdRGd",         "SUM",   "PmT",         "NONE",    "NONE",            "JUMPI",            "INDEX0",  "T",  "CALL_3"       ]
-  ],
-  "CALL_2":
-  [
-    ["PdMDRs",    "PdPCd",         "SUM",   "PmT",         "NONE",    "NONE",            "STEP",             "INDEX0",  "T",  "0"            ]
-  ],
-  "CALL_3":
-  [
-    ["PdSPs",     "NONE",          "SBUS",  "PmADR",       "NONE",    "-2SP",            "STEP",             "INDEX0",  "T",  "0"            ],
-    ["PdPCs",     "NONE",          "SBUS",  "PmMDR",       "WRITE",   "NONE",            "STEP",             "INDEX0",  "T",  "0"            ],
-    ["PdTs",      "NONE",          "SBUS",  "PmPC",        "NONE",    "NONE",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ]
-  ],
-  "JMP_AM":
-  [
-    ["PdPCs",     "NONE",          "SBUS",  "PmADR",       "READ",    "+2PC",            "JUMPI",            "INDEX0",  "T",  "JMP_AM_2"     ]
-  ],
-  "JMP_AD":
-  [
-    ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "JUMPI",            "INDEX0",  "T",  "ILLEGAL"      ]
-  ],
-  "JMP_AI":
-  [
-    ["NONE",      "PdRGd",         "DBUS",  "PmPC",        "NONE",    "NONE",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ]
-  ],
-  "JMP_AX":
-  [
-    ["PdPCs",     "NONE",          "SBUS",  "PmADR",       "READ",    "+2PC",            "STEP",             "INDEX0",  "T",  "0"            ],
-    ["PdMDRs",    "PdRGd",         "SUM",   "PmPC",        "NONE",    "NONE",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ]
-  ],
-  "JMP_AM_2":
-  [
-    ["PdMDRs",    "PdPCd",         "SUM",   "PmPC",        "NONE",    "NONE",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ]
-  ],
-  "CLC":
-  [
-    ["PdFLAGs",   "PdIR[7...0]d",    "AND",   "PmFLAG",      "NONE",    "NONE",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ],
-    ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "STEP",             "INDEX0",  "T",  "0"            ]
-  ],
-  "SEC":
-  [
-    ["PdFLAGs",   "PdIR[7...0]d",    "OR",    "PmFLAG",      "NONE",    "NONE",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ],
-    ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "STEP",             "INDEX0",  "T",  "0"            ]
-  ],
-  "NOP":
-  [
-    ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ],
-    ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "STEP",             "INDEX0",  "T",  "0"            ]
-  ],
-  "HALT":
-  [
-    ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "A(0)BPO",         "STEP",             "INDEX0",  "T",  "0"            ],
-    ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "STEP",             "INDEX0",  "T",  "0"            ]
-  ],
-  "EI":
-  [
-    ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "A(1)BVI",         "JUMPI",            "INDEX7",  "T",  "IFCH"         ],
-    ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "STEP",             "INDEX0",  "T",  "0"            ]
-  ],
-  "DI":
-  [
-    ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "A(0)BVI",         "JUMPI",            "INDEX0",  "T",  "IFCH"         ],
-    ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "STEP",             "INDEX0",  "T",  "0"            ]
-  ],
-  "PUSH PC":
-  [
-    ["PdSPs",     "NONE",          "SBUS",  "PmADR",       "NONE",    "-2SP",            "STEP",             "INDEX0",  "T",  "0"            ],
-    ["PdPCs",     "NONE",          "SBUS",  "PmMDR",       "WRITE",   "NONE",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ]
-  ],
-  "POP PC":
-  [
-    ["PdSPs",     "NONE",          "SBUS",  "PmADR",       "READ",    "NONE",            "STEP",             "INDEX0",  "T",  "0"            ],
-    ["PdMDRs",    "NONE",          "SBUS",  "PmPC",        "NONE",    "+2SP",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ]
-  ],
-  "PUSH FLAG":
-  [
-    ["PdSPs",     "NONE",          "SBUS",  "PmADR",       "NONE",    "-2SP",            "STEP",             "INDEX0",  "T",  "0"            ],
-    ["PdFLAGs",   "NONE",          "SBUS",  "PmMDR",       "WRITE",   "NONE",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ]
-  ],
-  "POP FLAG":
-  [
-    ["PdSPs",     "NONE",          "SBUS",  "PmADR",       "READ",    "NONE",            "STEP",             "INDEX0",  "T",  "0"            ],
-    ["PdMDRs",    "NONE",          "SBUS",  "PmFLAG",      "NONE",    "+2SP",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ]
-  ],
-  "RET":
-  [
-    ["PdSPs",     "NONE",          "SBUS",  "PmADR",       "READ",    "NONE",            "STEP",             "INDEX0",  "T",  "0"            ],
-    ["PdMDRs",    "NONE",          "SBUS",  "PmPC",        "NONE",    "+2SP",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ]
-  ],
-  "IRET":
-  [
-    ["PdSPs",     "NONE",          "SBUS",  "PmADR",       "READ",    "NONE",            "STEP",             "INDEX0",  "T",  "0"            ],
-    ["PdMDRs",    "NONE",          "SBUS",  "PmPC",        "NONE",    "+2SP",            "STEP",             "INDEX0",  "T",  "0"            ],
-    ["PdSPs",     "NONE",          "SBUS",  "PmADR",       "READ",    "NONE",            "STEP",             "INDEX0",  "T",  "0"            ],
-    ["PdMDRs",    "NONE",          "SBUS",  "PmFLAG",      "NONE",    "+2SP",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ]
-  ]
+    "IFCH":
+    [
+        ["PdPCs",     "NONE",          "SBUS",  "PmADR",       "IFCH",    "+2PC",            "IF ACLOW JUMPI",   "INDEX0",  "T",  "PWFAIL"       ],
+        ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "IF CIL JUMPI",     "INDEX1",  "F",  "B1"           ]
+    ],
+    "ILLEGAL":
+    [
+        ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "A(1)BE1",         "JUMPI",            "INDEX0",  "T",  "INT"          ]
+    ],
+    "PWFAIL":
+    [
+        ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "A(1)BE0",         "JUMPI",            "INDEX0",  "T",  "INT+1"          ]
+    ],
+    "INT":
+    [
+        ["PdSPs",     "NONE",          "SBUS",  "PmADR",       "NONE",    "INTA,-2SP",       "STEP",             "INDEX0",  "T",  "0"            ],
+        ["PdFLAGs",   "NONE",          "SBUS",  "PmMDR",       "NONE",    "-2SP",            "STEP",             "INDEX0",  "T",  "0"            ],
+        ["PdSPs",     "NONE",          "SBUS",  "PmADR",       "NONE",    "NONE",            "STEP",             "INDEX0",  "T",  "0"            ],
+        ["PdPCs",     "NONE",          "SBUS",  "PmMDR",       "WRITE",   "NONE",            "STEP",             "INDEX0",  "T",  "0"            ],
+        ["PdIVRs",    "NONE",          "SBUS",  "PmADR",       "READ",    "NONE",            "STEP",             "INDEX0",  "T",  "0"            ],
+        ["PdMDRs",    "NONE",          "SBUS",  "PmPC",        "NONE",    "A(0)BE,A(0)BI",   "JUMPI",            "INDEX0",  "T",  "IFCH"         ]
+    ],
+    "B1":
+    [
+        ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "JUMPI",            "INDEX2",  "T",  "FOS_AM"       ]
+    ],
+    "B2":
+    [
+        ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "JUMPI",            "INDEX3",  "T",  "FOD_AM_B2"    ]
+    ],
+    "B3":
+    [
+        ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "JUMPI",            "INDEX5",  "T",  "BEQ"          ]
+    ],
+    "B4":
+    [
+        ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "JUMPI",            "INDEX5",  "T",  "CLC"          ]
+    ],
+    "FOS_AM":
+    [
+        ["PdPCs",     "NONE",          "SBUS",  "PmADR",       "READ",    "+2PC",            "JUMPI",            "INDEX0",  "T",  "FOSEND"       ]
+    ],
+    "FOS_AD":
+    [
+        ["PdRGs",     "NONE",          "SBUS",  "PmT",         "NONE",    "NONE",            "JUMPI",            "INDEX3",  "T",  "FOD_AM_B1"    ]
+    ],
+    "FOS_AI":
+    [
+        ["PdRGs",     "NONE",          "SBUS",  "PmADR",       "READ",    "NONE",            "JUMPI",            "INDEX0",  "T",  "FOSEND"       ]
+    ],
+    "FOS_AX":
+    [
+        ["PdPCs",     "NONE",          "SBUS",  "PmADR",       "READ",    "+2PC",            "STEP",             "INDEX0",  "T",  "0"            ],
+        ["PdRGs",     "PdMDRd",        "SUM",   "PmADR",       "READ",    "NONE",            "STEP",             "INDEX0",  "T",  "0"            ]
+    ],
+    "FOSEND":
+    [
+        ["PdMDRs",    "NONE",          "SBUS",  "PmT",         "NONE",    "NONE",            "JUMPI",            "INDEX3",  "T",  "FOD_AM_B1"    ]
+    ],
+    "FOD_AM_B1":
+    [
+        ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "JUMPI",            "INDEX0",  "T",  "ILLEGAL"      ]
+    ],
+    "FOD_AD_B1":
+    [
+        ["NONE",      "PdRGd",         "DBUS",  "PmMDR",       "NONE",    "NONE",            "JUMPI",            "INDEX4",  "T",  "MOV"          ]
+    ],
+    "FOD_AI_B1":
+    [
+        ["NONE",      "PdRGd",         "DBUS",  "PmADR",       "READ",    "NONE",            "JUMPI",            "INDEX4",  "T",  "MOV"          ]
+    ],
+    "FOD_AX_B1":
+    [
+        ["NONE",      "PdPCd",         "DBUS",  "PmADR",       "READ",    "+2PC",            "STEP",             "INDEX0",  "T",  "0"            ],
+        ["PdMDRs",    "PdRGd",         "SUM",   "PmADR",       "READ",    "NONE",            "JUMPI",            "INDEX4",  "T",  "MOV"          ]
+    ],
+    "FOD_AM_B2":
+    [
+        ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "JUMPI",            "INDEX0",  "T",  "ILLEGAL"      ]
+    ],
+    "FOD_AD_B2":
+    [
+        ["NONE",      "PdRGd",         "DBUS",  "PmMDR",       "NONE",    "NONE",            "JUMPI",            "INDEX5",  "T",  "CLR"          ]
+    ],
+    "FOD_AI_B2":
+    [
+        ["NONE",      "PdRGd",         "DBUS",  "PmADR",       "READ",    "NONE",            "JUMPI",            "INDEX5",  "T",  "CLR"          ]
+    ],
+    "FOD_AX_B2":
+    [
+        ["NONE",      "PdPCd",         "DBUS",  "PmADR",       "READ",    "+2PC",            "STEP",             "INDEX0",  "T",  "0"            ],
+        ["PdMDRs",    "PdRGd",         "SUM",   "PmADR",       "READ",    "NONE",            "JUMPI",            "INDEX5",  "T",  "CLR"          ]
+    ],
+    "MOV":
+    [
+        ["PdTs",      "NONE",          "SBUS",  "PmMDR",       "NONE",    "NONE",            "JUMPI",            "INDEX3",  "T",  "WRD"          ]
+    ],
+    "ADD":
+    [
+        ["PdTs",      "PdMDRd",        "SUM",   "PmMDR",       "NONE",    "PdCONDaritm",     "JUMPI",            "INDEX3",  "T",  "WRD"          ]
+    ],
+    "SUB":
+    [
+        ["PdTsNeg",   "PdMDRd",        "SUM",   "PmMDR",       "NONE",    "Cin,PdCONDaritm", "JUMPI",            "INDEX3",  "T",  "WRD"          ]
+    ],
+    "CMP":
+    [
+        ["PdTsNeg",   "PdMDRd",        "SUM",   "NONE",        "NONE",    "Cin,PdCONDaritm", "JUMPI",            "INDEX7",  "T",  "IFCH"         ]
+    ],
+    "AND":
+    [
+        ["PdTs",      "PdMDRd",        "AND",   "PmMDR",       "NONE",    "PdCONDlog",       "JUMPI",            "INDEX3",  "T",  "WRD"          ]
+    ],
+    "OR":
+    [
+        ["PdTs",      "PdMDRd",        "OR",    "PmMDR",       "NONE",    "PdCONDlog",       "JUMPI",            "INDEX3",  "T",  "WRD"          ]
+    ],
+    "XOR":
+    [
+        ["PdTs",      "PdMDRd",        "XOR",   "PmMDR",       "NONE",    "PdCONDlog",       "JUMPI",            "INDEX3",  "T",  "WRD"          ]
+    ],
+    "CLR":
+    [
+        ["NONE",      "Pd0d",          "DBUS",  "PmMDR",       "NONE",    "PdCONDlog",       "JUMPI",            "INDEX3",  "T",  "WRD"          ]
+    ],
+    "NEG":
+    [
+        ["NONE",      "PdMDRdNeg",     "DBUS",  "PmMDR",       "NONE",    "PdCONDlog",       "JUMPI",            "INDEX3",  "T",  "WRD"          ]
+    ],
+    "INC":
+    [
+        ["Pd0s",      "PdMDRd",        "SUM",   "PmMDR",       "NONE",    "Cin,PdCONDaritm", "JUMPI",            "INDEX3",  "T",  "WRD"          ]
+    ],
+    "DEC":
+    [
+        ["Pd-1s",     "PdMDRd",        "SUM",   "PmMDR",       "NONE",    "PdCONDaritm",     "JUMPI",            "INDEX3",  "T",  "WRD"          ]
+    ],
+    "ASL":
+    [
+        ["NONE",      "PdMDRd",        "ASL",   "PmMDR",       "NONE",    "PdCONDaritm",     "JUMPI",            "INDEX3",  "T",  "WRD"          ]
+    ],
+    "ASR":
+    [
+        ["NONE",      "PdMDRd",        "ASR",   "PmMDR",       "NONE",    "PdCONDaritm",     "JUMPI",            "INDEX3",  "T",  "WRD"          ]
+    ],
+    "LSR":
+    [
+        ["NONE",      "PdMDRd",        "LSR",   "PmMDR",       "NONE",    "PdCONDlog",       "JUMPI",            "INDEX3",  "T",  "WRD"          ]
+    ],
+    "ROL":
+    [
+        ["NONE",      "PdMDRd",        "ROL",   "PmMDR",       "NONE",    "PdCONDlog",       "JUMPI",            "INDEX3",  "T",  "WRD"          ]
+    ],
+    "ROR":
+    [
+        ["NONE",      "PdMDRd",        "ROR",   "PmMDR",       "NONE",    "PdCONDlog",       "JUMPI",            "INDEX3",  "T",  "WRD"          ]
+    ],
+    "RLC":
+    [
+        ["NONE",      "PdMDRd",        "RLC",   "PmMDR",       "NONE",    "PdCONDlog",       "JUMPI",            "INDEX3",  "T",  "WRD"          ]
+    ],
+    "RRC":
+    [
+        ["NONE",      "PdMDRd",        "RRC",   "PmMDR",       "NONE",    "PdCONDlog",       "JUMPI",            "INDEX3",  "T",  "WRD"          ]
+    ],
+    "PUSH":
+    [
+        ["PdSPs",     "NONE",          "SBUS",  "PmADR",       "WRITE",   "-2SP",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ]
+    ],
+    "POP":
+    [
+        ["PdADRs",    "NONE",          "SBUS",  "PmT",         "NONE",    "+2SP",             "STEP",             "INDEX0",  "T",  "0"            ],
+        ["PdSPs",     "NONE",          "SBUS",  "PmADR",       "READ",    "NONE",            "STEP",             "INDEX0",  "T",  "0"            ],
+        ["PdTs",      "NONE",          "SBUS",  "PmADR",       "NONE",    "NONE",            "JUMPI",            "INDEX3",  "T",  "WRD"          ]
+    ],
+    "WRD":
+    [
+        ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "JUMPI",            "INDEX0",  "T",  "ILLEGAL"      ],
+        ["PdMDRs",    "NONE",          "SBUS",  "PmRG",        "NONE",    "NONE",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ],
+        ["NONE",      "NONE",          "NONE",  "NONE",        "WRITE",   "NONE",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ],
+        ["NONE",      "NONE",          "NONE",  "NONE",        "WRITE",   "NONE",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ]
+    ],
+    "BEQ":
+    [
+        ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "IF Z JUMPI",       "INDEX3",  "T",  "JMP_AM"       ],
+        ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ]
+    ],
+    "BNE":
+    [
+        ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "IF Z JUMPI",       "INDEX3",  "F",  "JMP_AM"       ],
+        ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ]
+    ],
+    "BMI":
+    [
+        ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "IF S JUMPI",       "INDEX3",  "T",  "JMP_AM"       ],
+        ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ]
+    ],
+    "BPL":
+    [
+        ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "IF S JUMPI",       "INDEX3",  "F",  "JMP_AM"       ],
+        ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ]
+    ],
+    "BCS":
+    [
+        ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "IF C JUMPI",       "INDEX3",  "T",  "JMP_AM"       ],
+        ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ]
+    ],
+    "BCC":
+    [
+        ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "IF C JUMPI",       "INDEX3",  "F",  "JMP_AM"       ],
+        ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ]
+    ],
+    "BVS":
+    [
+        ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "IF V JUMPI",       "INDEX3",  "T",  "JMP_AM"       ],
+        ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ]
+    ],
+    "BVC":
+    [
+        ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "IF V JUMPI",       "INDEX3",  "F",  "JMP_AM"       ],
+        ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ]
+    ],
+    "JMP":
+    [
+        ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "JUMPI",            "INDEX3",  "T",  "JMP_AM"       ],
+        ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "STEP",             "INDEX0",  "T",  "0"            ]
+    ],
+    "CALL":
+    [
+        ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "JUMPI",            "INDEX3",  "T",  "CALL_AM"      ]
+    ],
+    "CALL_AM":
+    [
+        ["PdPCs",     "NONE",          "SBUS",  "PmADR",       "READ",    "+2PC",            "JUMPI",            "INDEX0",  "T",  "CALL_2"       ]
+    ],
+    "CALL_AD":
+    [
+        ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "JUMPI",            "INDEX0",  "T",  "ILLEGAL"      ]
+    ],
+    "CALL_AI":
+    [
+        ["NONE",      "PdRGd",         "DBUS",  "PmT",         "NONE",    "NONE",            "JUMPI",            "INDEX0",  "T",  "CALL_3"       ]
+    ],
+    "CALL_AX":
+    [
+        ["PdPCs",     "NONE",          "SBUS",  "PmADR",       "READ",    "+2PC",            "STEP",             "INDEX0",  "T",  "0"            ],
+        ["PdMDRs",    "PdRGd",         "SUM",   "PmT",         "NONE",    "NONE",            "JUMPI",            "INDEX0",  "T",  "CALL_3"       ]
+    ],
+    "CALL_2":
+    [
+        ["PdMDRs",    "PdPCd",         "SUM",   "PmT",         "NONE",    "NONE",            "STEP",             "INDEX0",  "T",  "0"            ]
+    ],
+    "CALL_3":
+    [
+        ["PdSPs",     "NONE",          "SBUS",  "PmADR",       "NONE",    "-2SP",            "STEP",             "INDEX0",  "T",  "0"            ],
+        ["PdPCs",     "NONE",          "SBUS",  "PmMDR",       "WRITE",   "NONE",            "STEP",             "INDEX0",  "T",  "0"            ],
+        ["PdTs",      "NONE",          "SBUS",  "PmPC",        "NONE",    "NONE",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ]
+    ],
+    "JMP_AM":
+    [
+        ["PdPCs",     "NONE",          "SBUS",  "PmADR",       "READ",    "+2PC",            "JUMPI",            "INDEX0",  "T",  "JMP_AM_2"     ]
+    ],
+    "JMP_AD":
+    [
+        ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "JUMPI",            "INDEX0",  "T",  "ILLEGAL"      ]
+    ],
+    "JMP_AI":
+    [
+        ["NONE",      "PdRGd",         "DBUS",  "PmPC",        "NONE",    "NONE",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ]
+    ],
+    "JMP_AX":
+    [
+        ["PdPCs",     "NONE",          "SBUS",  "PmADR",       "READ",    "+2PC",            "STEP",             "INDEX0",  "T",  "0"            ],
+        ["PdMDRs",    "PdRGd",         "SUM",   "PmPC",        "NONE",    "NONE",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ]
+    ],
+    "JMP_AM_2":
+    [
+        ["PdMDRs",    "PdPCd",         "SUM",   "PmPC",        "NONE",    "NONE",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ]
+    ],
+    "CLC":
+    [
+        ["PdFLAGs",   "PdIR[7...0]d",  "AND",   "PmFLAG",      "NONE",    "NONE",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ],
+        ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "STEP",             "INDEX0",  "T",  "0"            ]
+    ],
+    "SEC":
+    [
+        ["PdFLAGs",   "PdIR[7...0]d",  "OR",    "PmFLAG",      "NONE",    "NONE",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ],
+        ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "STEP",             "INDEX0",  "T",  "0"            ]
+    ],
+    "NOP":
+    [
+        ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ],
+        ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "STEP",             "INDEX0",  "T",  "0"            ]
+    ],
+    "HALT":
+    [
+        ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "A(0)BPO",         "STEP",             "INDEX0",  "T",  "0"            ],
+        ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "STEP",             "INDEX0",  "T",  "0"            ]
+    ],
+    "EI":
+    [
+        ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "A(1)BVI",         "JUMPI",            "INDEX7",  "T",  "IFCH"         ],
+        ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "STEP",             "INDEX0",  "T",  "0"            ]
+    ],
+    "DI":
+    [
+        ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "A(0)BVI",         "JUMPI",            "INDEX0",  "T",  "IFCH"         ],
+        ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "STEP",             "INDEX0",  "T",  "0"            ]
+    ],
+    "PUSH PC":
+    [
+        ["PdSPs",     "NONE",          "SBUS",  "PmADR",       "NONE",    "-2SP",            "STEP",             "INDEX0",  "T",  "0"            ],
+        ["PdPCs",     "NONE",          "SBUS",  "PmMDR",       "WRITE",   "NONE",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ]
+    ],
+    "POP PC":
+    [
+        ["PdSPs",     "NONE",          "SBUS",  "PmADR",       "READ",    "NONE",            "STEP",             "INDEX0",  "T",  "0"            ],
+        ["PdMDRs",    "NONE",          "SBUS",  "PmPC",        "NONE",    "+2SP",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ]
+    ],
+    "PUSH FLAG":
+    [
+        ["PdSPs",     "NONE",          "SBUS",  "PmADR",       "NONE",    "-2SP",            "STEP",             "INDEX0",  "T",  "0"            ],
+        ["PdFLAGs",   "NONE",          "SBUS",  "PmMDR",       "WRITE",   "NONE",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ]
+    ],
+    "POP FLAG":
+    [
+        ["PdSPs",     "NONE",          "SBUS",  "PmADR",       "READ",    "NONE",            "STEP",             "INDEX0",  "T",  "0"            ],
+        ["PdMDRs",    "NONE",          "SBUS",  "PmFLAG",      "NONE",    "+2SP",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ]
+    ],
+    "RET":
+    [
+        ["PdSPs",     "NONE",          "SBUS",  "PmADR",       "READ",    "NONE",            "STEP",             "INDEX0",  "T",  "0"            ],
+        ["PdMDRs",    "NONE",          "SBUS",  "PmPC",        "NONE",    "+2SP",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ]
+    ],
+    "IRET":
+    [
+        ["PdSPs",     "NONE",          "SBUS",  "PmADR",       "READ",    "NONE",            "STEP",             "INDEX0",  "T",  "0"            ],
+        ["PdMDRs",    "NONE",          "SBUS",  "PmPC",        "NONE",    "+2SP",            "STEP",             "INDEX0",  "T",  "0"            ],
+        ["PdSPs",     "NONE",          "SBUS",  "PmADR",       "READ",    "NONE",            "STEP",             "INDEX0",  "T",  "0"            ],
+        ["PdMDRs",    "NONE",          "SBUS",  "PmFLAG",      "NONE",    "+2SP",            "JUMPI",            "INDEX7",  "T",  "IFCH"         ]
+    ]
 }

--- a/Ui/Interfaces/Services/IAssemblerService.cs
+++ b/Ui/Interfaces/Services/IAssemblerService.cs
@@ -2,6 +2,8 @@
 
 public interface IAssemblerService
 {
+    public Dictionary<short, ushort> DebugSymbols { get; set; }
+
     event EventHandler<byte[]> SourceCodeAssembled;
     
     byte[] AssembleSourceCodeService(string sourceCode);

--- a/Ui/Interfaces/Services/ICpuService.cs
+++ b/Ui/Interfaces/Services/ICpuService.cs
@@ -11,4 +11,5 @@ public interface ICpuService
     public void ResetProgram();
     public void StartDebugging();
     public void StopDebugging();
+    public void SetDebugSymbols(Dictionary<short, ushort> debugSymbols);
 }

--- a/Ui/Interfaces/ViewModel/IActionsBarViewModel.cs
+++ b/Ui/Interfaces/ViewModel/IActionsBarViewModel.cs
@@ -24,7 +24,8 @@ public interface IActionsBarViewModel
     global::CommunityToolkit.Mvvm.Input.IRelayCommand ResetProgramCommand { get; }
 
     bool IsDebugging { get; set; }
-    bool NotDebugging { get; set; }
+    bool CanDebug { get; set; }
+    bool IsEditor { get; set; }
 
     event EventHandler<byte[]>? ObjectCodeGenerated;
 

--- a/Ui/Interfaces/ViewModel/IActionsBarViewModel.cs
+++ b/Ui/Interfaces/ViewModel/IActionsBarViewModel.cs
@@ -25,7 +25,7 @@ public interface IActionsBarViewModel
 
     bool IsDebugging { get; set; }
     bool CanDebug { get; set; }
-    bool IsEditor { get; set; }
+    bool CanAssemble { get; set; }
 
     event EventHandler<byte[]>? ObjectCodeGenerated;
 

--- a/Ui/Services/AssemblerService.cs
+++ b/Ui/Services/AssemblerService.cs
@@ -9,6 +9,7 @@ public class AssemblerService : IAssemblerService
     private readonly ASMBLR _assembler;
     private readonly IMainMemory _mainMemory;
     public event EventHandler<byte[]>? SourceCodeAssembled;
+    public Dictionary<short, ushort> DebugSymbols { get; set; }
 
     public AssemblerService(ASMBLR assembler, IMainMemory memory)
     {
@@ -22,7 +23,7 @@ public class AssemblerService : IAssemblerService
         _mainMemory.LoadMachineCode(objectCode);
         
         SourceCodeAssembled?.Invoke(this, objectCode);
-        
+        DebugSymbols =  _assembler.GetDebugSymbols();
         return objectCode;
     }
 }

--- a/Ui/Services/CpuService.cs
+++ b/Ui/Services/CpuService.cs
@@ -18,7 +18,7 @@ public class CpuService : ICpuService
     private readonly IDiagramViewModel _diagram;
     private FileViewModel? _fileViewModel;
     Color _semiTransparentYellow;
-    int i = 1;
+    private Dictionary<short, ushort> _debugSymbls;
     public HighlightCurrentLineBackgroundRenderer? Highlight
     {
         get;
@@ -32,6 +32,7 @@ public class CpuService : ICpuService
         _microprogramService = microprogramService;
         _semiTransparentYellow = Color.FromArgb(38, 255, 255, 0);
         _ = LoadJsonMpm();
+        _debugSymbls = new Dictionary<short, ushort>();
     }
 
     public async Task LoadJsonMpm(string filePath = "", bool debug = false)
@@ -67,7 +68,8 @@ public class CpuService : ICpuService
 
         if (Highlight != null && _fileViewModel != null && _fileViewModel.EditorInstance != null)
         {
-            Highlight?.SetLine(++i);
+            if (_debugSymbls.ContainsKey(_cpu.Registers[REGISTERS.PC]))
+                Highlight?.SetLine(_debugSymbls[_cpu.Registers[REGISTERS.PC]]);
         }
         return (row, column);
     }
@@ -84,7 +86,8 @@ public class CpuService : ICpuService
     {
         if (_fileViewModel?.EditorInstance != null)
         {
-            Highlight = new HighlightCurrentLineBackgroundRenderer(_fileViewModel.EditorInstance, i, _semiTransparentYellow);
+            ushort lineNum = _debugSymbls[_cpu.Registers[REGISTERS.PC]];
+            Highlight = new HighlightCurrentLineBackgroundRenderer(_fileViewModel.EditorInstance, lineNum, _semiTransparentYellow);
             _fileViewModel.EditorInstance.TextArea.TextView.BackgroundRenderers.Add(Highlight);
         }
     }
@@ -95,5 +98,9 @@ public class CpuService : ICpuService
             _fileViewModel.EditorInstance.TextArea.TextView.BackgroundRenderers.Remove(Highlight);
             Highlight = null;
         }
+    }
+    public void SetDebugSymbols(Dictionary<short, ushort> debugSymbols)
+    {
+        _debugSymbls = debugSymbols;
     }
 }

--- a/Ui/ViewModels/Generics/ActionsBarViewModel.cs
+++ b/Ui/ViewModels/Generics/ActionsBarViewModel.cs
@@ -12,11 +12,12 @@ public partial class ActionsBarViewModel : ObservableObject, IActionsBarViewMode
     private readonly IAssemblerService _assemblerService;
     private readonly ICpuService _cpuService;
     private readonly IToolVisibilityService _toolVisibilityService;
-
     [ObservableProperty]
     public partial bool IsDebugging { get; set; }
     [ObservableProperty]
-    public partial bool NotDebugging { get; set; }
+    public partial bool CanDebug { get; set; }
+    [ObservableProperty]
+    public partial bool IsEditor{ get; set; }
 
     public ActionsBarViewModel(IAssemblerService assemblerService, IActiveDocumentService activeDocumentService, ICpuService cpuService, IToolVisibilityService toolVisibilityService)
     {
@@ -25,7 +26,8 @@ public partial class ActionsBarViewModel : ObservableObject, IActionsBarViewMode
         _cpuService = cpuService;
         _toolVisibilityService = toolVisibilityService;
         IsDebugging = false;
-        NotDebugging = true;
+        CanDebug = false;
+        IsEditor = false;
         ObjectCodeGenerated += OnObjectCodeGenerated;
     }
 
@@ -39,6 +41,7 @@ public partial class ActionsBarViewModel : ObservableObject, IActionsBarViewMode
         ObjectCodeGenerated?.Invoke(this, objectCode);
         
         _toolVisibilityService.ToggleToolVisibility(_activeDocumentService.HexViewer);
+        CanDebug = true;
     }
     
     [RelayCommand]
@@ -68,9 +71,10 @@ public partial class ActionsBarViewModel : ObservableObject, IActionsBarViewMode
     {
         if (_activeDocumentService.SelectedDocument != null)
         {
+            _cpuService.SetDebugSymbols(_assemblerService.DebugSymbols);
             _cpuService.StartDebugging();
             IsDebugging = true;
-            NotDebugging = false;
+            CanDebug = false;
         }
     }
     [RelayCommand]
@@ -80,7 +84,7 @@ public partial class ActionsBarViewModel : ObservableObject, IActionsBarViewMode
         {
             _cpuService.StopDebugging();
             IsDebugging = false;
-            NotDebugging = true;
+            CanDebug = true;
         }
     }
     [RelayCommand]

--- a/Ui/ViewModels/Generics/ActionsBarViewModel.cs
+++ b/Ui/ViewModels/Generics/ActionsBarViewModel.cs
@@ -17,7 +17,7 @@ public partial class ActionsBarViewModel : ObservableObject, IActionsBarViewMode
     [ObservableProperty]
     public partial bool CanDebug { get; set; }
     [ObservableProperty]
-    public partial bool IsEditor{ get; set; }
+    public partial bool CanAssemble{ get; set; }
 
     public ActionsBarViewModel(IAssemblerService assemblerService, IActiveDocumentService activeDocumentService, ICpuService cpuService, IToolVisibilityService toolVisibilityService)
     {
@@ -27,7 +27,7 @@ public partial class ActionsBarViewModel : ObservableObject, IActionsBarViewMode
         _toolVisibilityService = toolVisibilityService;
         IsDebugging = false;
         CanDebug = false;
-        IsEditor = false;
+        CanAssemble = false;
         ObjectCodeGenerated += OnObjectCodeGenerated;
     }
 
@@ -42,6 +42,7 @@ public partial class ActionsBarViewModel : ObservableObject, IActionsBarViewMode
         
         _toolVisibilityService.ToggleToolVisibility(_activeDocumentService.HexViewer);
         CanDebug = true;
+        CanAssemble = false;
     }
     
     [RelayCommand]
@@ -75,6 +76,7 @@ public partial class ActionsBarViewModel : ObservableObject, IActionsBarViewMode
             _cpuService.StartDebugging();
             IsDebugging = true;
             CanDebug = false;
+            CanAssemble = false;
         }
     }
     [RelayCommand]
@@ -85,6 +87,7 @@ public partial class ActionsBarViewModel : ObservableObject, IActionsBarViewMode
             _cpuService.StopDebugging();
             IsDebugging = false;
             CanDebug = true;
+            CanAssemble = true;
         }
     }
     [RelayCommand]

--- a/Ui/Views/Windows/MainWindow.xaml
+++ b/Ui/Views/Windows/MainWindow.xaml
@@ -125,7 +125,7 @@
 
             <ui:Button
                 Command="{Binding StartDebugCommand}"
-                IsEnabled="{Binding NotDebugging}"
+                IsEnabled="{Binding CanDebug}"
                 VerticalAlignment="Top"
                 ToolTip="Debug"
                 Height="30"
@@ -139,6 +139,7 @@
 
             <ui:Button Command="{Binding RunAssembleSourceCodeServiceCommand}"
                        ToolTip="Assemble"
+                       IsEnabled="{Binding IsEditor}"
                        VerticalAlignment="Top"
                        Height="30"
                        Width="30"
@@ -227,6 +228,7 @@
                                 FontFamily="Consolas"
                                 FontSize="10pt"
                                 ShowLineNumbers="True"
+                                TextChanged="OnTextChanged"
                                 Text="{Binding Content, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}"
                                 Loaded="OnEditorLoaded"/>
                         </DataTemplate>

--- a/Ui/Views/Windows/MainWindow.xaml
+++ b/Ui/Views/Windows/MainWindow.xaml
@@ -139,7 +139,7 @@
 
             <ui:Button Command="{Binding RunAssembleSourceCodeServiceCommand}"
                        ToolTip="Assemble"
-                       IsEnabled="{Binding IsEditor}"
+                       IsEnabled="{Binding CanAssemble}"
                        VerticalAlignment="Top"
                        Height="30"
                        Width="30"
@@ -223,6 +223,7 @@
                     <components:PanesTemplateSelector.FileViewTemplate>
                         <DataTemplate DataType="{x:Type viewmodels:FileViewModel}">
                             <components:StyledAvalonEdit
+                                IsReadOnly="{Binding DataContext.ActionsBar.IsDebugging,RelativeSource={RelativeSource AncestorType=Window}}"
                                 x:Name="TextEditor"
                                 SyntaxHighlighting="Custom"
                                 FontFamily="Consolas"

--- a/Ui/Views/Windows/MainWindow.xaml.cs
+++ b/Ui/Views/Windows/MainWindow.xaml.cs
@@ -14,15 +14,18 @@ namespace Ui.Views.Windows;
 public partial class MainWindow
 {
     ICpuService _cpuService;
+    IActionsBarViewModel _actionsBarViewModel;
     public MainWindow(
         IMainWindowViewModel viewModel,
-        ICpuService cpuService
+        ICpuService cpuService,
+        IActionsBarViewModel actionsBarViewModel
     )
     {
         DataContext = viewModel;
         SystemThemeWatcher.Watch(this);
         InitializeComponent();
         _cpuService = cpuService;
+        _actionsBarViewModel = actionsBarViewModel;
     }
 
     public void SetServiceProvider(IServiceProvider serviceProvider)
@@ -85,6 +88,16 @@ public partial class MainWindow
         {
             vm.EditorInstance = editor;
             _cpuService.SetActiveEditor(vm);
+            _actionsBarViewModel.IsEditor = true;
+            editor.Unloaded += OnEditorUnloaded;
         }
+    }
+    private void OnTextChanged(object sender, EventArgs e)
+    {
+        _actionsBarViewModel.CanDebug = false;
+    }
+    private void OnEditorUnloaded(object sender, EventArgs e)
+    {
+        _actionsBarViewModel.IsEditor = false;
     }
 }

--- a/Ui/Views/Windows/MainWindow.xaml.cs
+++ b/Ui/Views/Windows/MainWindow.xaml.cs
@@ -88,16 +88,17 @@ public partial class MainWindow
         {
             vm.EditorInstance = editor;
             _cpuService.SetActiveEditor(vm);
-            _actionsBarViewModel.IsEditor = true;
+            _actionsBarViewModel.CanAssemble = true;
             editor.Unloaded += OnEditorUnloaded;
         }
     }
     private void OnTextChanged(object sender, EventArgs e)
     {
         _actionsBarViewModel.CanDebug = false;
+        _actionsBarViewModel.CanAssemble = true;
     }
     private void OnEditorUnloaded(object sender, EventArgs e)
     {
-        _actionsBarViewModel.IsEditor = false;
+        _actionsBarViewModel.CanAssemble = false;
     }
 }


### PR DESCRIPTION
# What has been done?

## What the branch was intended for
Added debug symbols, to sync the PC with the line number of the text assembly. Meaning when the pc is at address 0 the highlight will be at the line number 2 for this code:
``` asm
line num 1 proc start
line num 2 mov ro, 1 ; here will be the highlight for pc = 0
....
```
## Other bug fixes and improvements
- Added proper reset and stop debugging when pressing reset and stop buttons
- Prevent edditing when debugging
- Prevent assembling when the code doesnt change. Now you can assemble only when you do changes to the code.
- Sync the MPM microcommand highlight with the actual one of the cpu. Now the order is: sbus, dbus, other, alu, memory op, index, etc.

# Testing?

Run the app, test the buttons, see that the highlight is set approximately where it should when debugging.
The instructions are still not executed as they should, further fixes will arrive