### PR TITLE
fix: Fixed bug in user code highlight

### DIFF
--- a/Assembler.Business/Assembler.cs
+++ b/Assembler.Business/Assembler.cs
@@ -23,7 +23,7 @@ namespace Assembler.Business
         {
             Encoder = new Encoder();
             Grammar = new CiscGrammar();
-            Parser  = new Parser(Grammar);
+            Parser = new Parser(Grammar);
         }
         public byte[] Assemble(string sourceCode, out int len)
         {
@@ -46,7 +46,12 @@ namespace Assembler.Business
         }
         public Dictionary<short, ushort> GetDebugSymbols()
         {
-            return Encoder.DebugSymbols;
+            return new Dictionary<short, ushort>(Encoder.DebugSymbols);
+        }
+
+        public void SetInternalDebugSymbols(Dictionary<short, ushort> dbgSymbols)
+        {
+            this.Encoder.DebugSymbols = dbgSymbols;
         }
     }
 }

--- a/Assembler.Business/Encoder.cs
+++ b/Assembler.Business/Encoder.cs
@@ -150,7 +150,7 @@ namespace Assembler.Business
             }
         }
         public readonly Dictionary<string, ushort> SymbolTable = new Dictionary<string, ushort>();
-        public readonly Dictionary<short, ushort> DebugSymbols = new Dictionary<short, ushort>();
+        public Dictionary<short, ushort> DebugSymbols = new Dictionary<short, ushort>();
         readonly Dictionary<string, Dictionary<ushort,string>> _oppcodes = new Dictionary<string, Dictionary<ushort,string>>
         {
             // Numerical value    ,                                     Mnemonic, Type

--- a/Ui/Services/AssemblerService.cs
+++ b/Ui/Services/AssemblerService.cs
@@ -40,6 +40,7 @@ public class AssemblerService : IAssemblerService
     {
 
         var objectCode = _assembler.Assemble(sourceCode, out _);
+        var originalDbgSymbols = _assembler.GetDebugSymbols();
         _mainMemory.LoadMachineCode(objectCode);
 
         this.Isrs = ReadIVTJson();
@@ -53,6 +54,7 @@ public class AssemblerService : IAssemblerService
         }
 
         SourceCodeAssembled?.Invoke(this, objectCode);
+        _assembler.SetInternalDebugSymbols(originalDbgSymbols);
         DebugSymbols = _assembler.GetDebugSymbols();
         return objectCode;
     }

--- a/Ui/Services/CpuService.cs
+++ b/Ui/Services/CpuService.cs
@@ -74,11 +74,12 @@ public class CpuService : ICpuService
         if (row == 0 && column == 0)
         {
             _microprogramService.ClearAllHighlightedRows();
-
+            
             if (Highlight != null && _fileViewModel != null && _fileViewModel.EditorInstance != null)
             {
-                if (_debugSymbls.ContainsKey(_cpu.Registers[REGISTERS.PC]))
-                    Highlight?.SetLine(_debugSymbls[_cpu.Registers[REGISTERS.PC]]);
+                short index = (short)(_cpu.Registers[REGISTERS.PC] - 16);
+                if (_debugSymbls.ContainsKey(index))
+                    Highlight?.SetLine(_debugSymbls[index]);
             }
         }
 
@@ -105,8 +106,9 @@ public class CpuService : ICpuService
 
         if (Highlight != null && _fileViewModel != null && _fileViewModel.EditorInstance != null)
         {
-            if (_debugSymbls.ContainsKey(_cpu.Registers[REGISTERS.PC]))
-                Highlight?.SetLine(_debugSymbls[_cpu.Registers[REGISTERS.PC]]);
+            short index = (short)(_cpu.Registers[REGISTERS.PC] - 16);
+            if (_debugSymbls.ContainsKey(index))
+                Highlight?.SetLine(_debugSymbls[index]);
         }
     }
     public void StepInstruction()
@@ -123,8 +125,9 @@ public class CpuService : ICpuService
 
         if (Highlight != null && _fileViewModel != null && _fileViewModel.EditorInstance != null)
         {
-            if (_debugSymbls.ContainsKey(_cpu.Registers[REGISTERS.PC]))
-                Highlight?.SetLine(_debugSymbls[_cpu.Registers[REGISTERS.PC]]);
+            short index = (short)(_cpu.Registers[REGISTERS.PC] - 16);
+            if (_debugSymbls.ContainsKey(index))
+                Highlight?.SetLine(_debugSymbls[index]);
         }
     }
     public void ResetProgram()


### PR DESCRIPTION
# What is the issue?
As mentioned in the ticket, the highlight for user code has been broken due to changes in how memory layout works and PC value.

# What has been done?
Mainly applied offset to portions of code that need PC as index value.