### PR TITLE
fix: Updated logic for hiding the Tools windows

### DIFF
--- a/Ui/Views/Windows/MainWindow.xaml.cs
+++ b/Ui/Views/Windows/MainWindow.xaml.cs
@@ -91,15 +91,21 @@ public partial class MainWindow
         menuBar.SetToolsVisibilityOnAndOff();
         _docking.LoadLastUsedLayout();
     }
-
     private void DockManager_AnchorableClosing(object? sender, AnchorableClosingEventArgs e)
     {
-        if (e.Anchorable.Content is not IToolViewModel toolVm) return;
-        
-        toolVm.IsVisible = false;
-        e.Cancel = true;
-    }
+        System.Diagnostics.Debug.WriteLine($"Closing tool: {e.Anchorable.Title}");
 
+        if (e.Anchorable.Content is IToolViewModel tool)
+        {
+            System.Diagnostics.Debug.WriteLine($"Before: IsVisible = {tool.IsVisible}");
+
+            tool.IsVisible = false;
+            e.Anchorable.Hide();
+
+            System.Diagnostics.Debug.WriteLine($"After: IsVisible = {tool.IsVisible}");
+            e.Cancel = true;
+        }
+    }
     protected override void OnClosing(CancelEventArgs e)
     {
         _docking.SaveLastUsedLayout();


### PR DESCRIPTION
# What is the issue?
The user cannot close any of the windows from Tools via the 'Close' button.
<img width="1169" height="354" alt="image" src="https://github.com/user-attachments/assets/37239437-d5f7-4142-b0ae-d979eb1dc3b3" />

# What has been done?
Updated logic for MainWindow view.